### PR TITLE
Fix bug if PBX_HMAC is null

### DIFF
--- a/Paybox/AbstractRequest.php
+++ b/Paybox/AbstractRequest.php
@@ -102,7 +102,7 @@ abstract class AbstractRequest implements RequestInterface
      */
     protected function stringifyParameters()
     {
-        if (isset($this->parameters['PBX_HMAC'])) {
+        f (array_key_exists('PBX_HMAC', $this->parameters)) {
             unset($this->parameters['PBX_HMAC']);
         }
 


### PR DESCRIPTION
I need to have some paybox form call on a same page, when I call my second form I reset the value of PBX_HMAC at null like : 
$this->get('lexik_paybox.request_handler')->setParameter('PBX_HMAC', null)
But because PBX_HMAC is null, isset is false, we need to have array_key_exists to generate the right HMAC without the &PBX_HMAC= in the stringifyParameters function
Thanks
